### PR TITLE
Access control

### DIFF
--- a/app/controllers/jobs_controller.rb
+++ b/app/controllers/jobs_controller.rb
@@ -2,7 +2,11 @@ class JobsController < ApplicationController
 
   def index
     if @repo = Repo.find_by(login: params[:org], name: params[:repo_name])
-      @jobs = @repo.jobs.order('id DESC')
+      if @repo.user_has_access?(current_user)
+        @jobs = @repo.jobs.order('id DESC')
+      else
+        render plain: "404 Not Found", status: 404
+      end
     else
       render plain: "404 Not Found", status: 404 and return unless @repo
     end

--- a/app/controllers/repos_controller.rb
+++ b/app/controllers/repos_controller.rb
@@ -4,11 +4,11 @@ class ReposController < ApplicationController
 
   def index
     if org = params[:org]
-      @repos = Repo.where(login: org).group_by(&:login)
+      @repos = Repo.where(login: org).where(is_private: false).group_by(&:login)
       @all_repos = Repo.all.group_by(&:login)
       not_found if @repos.none?
     else
-      @repos = Repo.all.preload(:jobs).group_by(&:login)
+      @repos = Repo.all.preload(:jobs).where(is_private: false).group_by(&:login)
       @all_repos = @repos
     end
   end

--- a/app/controllers/source_files_controller.rb
+++ b/app/controllers/source_files_controller.rb
@@ -2,15 +2,23 @@ class SourceFilesController < ApplicationController
 
   def index
     @repo = Repo.find_by(login: params[:org], name: params[:repo_name])
-    @job = @repo.jobs.find_by(id: params[:job_id])
-    @source_files = @job.source_files
+    if @repo.user_has_access?(current_user)
+      @job = @repo.jobs.find_by(id: params[:job_id])
+      @source_files = @job.source_files
+    else
+      render plain: "404 Not Found", status: 404
+    end
   end
 
   def show
     @repo = Repo.find_by(login: params[:org], name: params[:repo_name])
-    @job = @repo.jobs.find_by(id: params[:job_id])
-    @file = SourceFile.find_by_id(params[:source_id])
-    @lines = @file.source.split("\n")
+    if @repo.user_has_access?(current_user)
+      @job = @repo.jobs.find_by(id: params[:job_id])
+      @file = SourceFile.find_by_id(params[:source_id])
+      @lines = @file.source.split("\n")
+    else
+      render plain: "404 Not Found", status: 404
+    end
   end
 
 end

--- a/app/models/repo.rb
+++ b/app/models/repo.rb
@@ -12,6 +12,7 @@ class Repo < ActiveRecord::Base
     repo.login = params[:owner][:login]
     repo.full_name = params[:full_name]
     repo.name = params[:name]
+    repo.is_private = params[:private]
     repo.set_repo_token
     repo
   end
@@ -27,5 +28,17 @@ class Repo < ActiveRecord::Base
 
   def job_for_branch(branch)
     self.jobs.where(branch: branch).last
+  end
+
+  def user_has_access?(user)
+    granted = false
+    unless self.is_private?
+      return true
+    end
+    if user
+      client = Octokit::Client.new(access_token: user.access_token)
+      granted = client.collaborator?(full_name, login)
+    end
+    granted
   end
 end

--- a/db/migrate/20150417131425_add_repo_access_control.rb
+++ b/db/migrate/20150417131425_add_repo_access_control.rb
@@ -1,0 +1,7 @@
+class AddRepoAccessControl < ActiveRecord::Migration
+  def change
+    change_table :repos do |t|
+      t.boolean  "is_private"
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150227154746) do
+ActiveRecord::Schema.define(version: 20150417131425) do
 
   create_table "jobs", force: true do |t|
     t.string   "service_job_id"
@@ -34,6 +34,7 @@ ActiveRecord::Schema.define(version: 20150227154746) do
     t.datetime "updated_at"
     t.string   "repo_token"
     t.integer  "jobs_count", default: 0
+    t.boolean  "is_private"
   end
 
   create_table "source_files", force: true do |t|
@@ -47,11 +48,6 @@ ActiveRecord::Schema.define(version: 20150227154746) do
   end
 
   add_index "source_files", ["job_id"], name: "index_source_files_on_job_id", using: :btree
-
-  create_table "user_repos", force: true do |t|
-    t.integer "user_id"
-    t.integer "repo_id"
-  end
 
   create_table "users", force: true do |t|
     t.string   "provider"


### PR DESCRIPTION
This means:

* / route only shows public repos because of performance reasons and
 the way our database is structured
* /:org oute shows public repos only too for the same reasons
* /:org/:repo route checks if the user is a collaborator and if he is
 not he will be faced with a 404
* /:org/:repo/:job route also checks if the user is a collaborator and
 if he is not he will be face with a 404 too
* All the changes are consistent with the GitHub access rights which
 also renders a 404