### PR TITLE
Add missing packages to playbook

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -10,6 +10,11 @@
         - mysql-server
         - mysql-client
         - libmysqlclient-dev
+        - imagemagick
+        - libmagickwand-dev
+        - build-essential
+        - g++
+        - nodejs
 
     - name: Symlink exists for Ruby 2.0
       file: src=/usr/bin/ruby2.0 dest=/usr/local/bin/ruby state=link


### PR DESCRIPTION
During the vagrant setup I stumble upon the following error:

```
Installing rmagick 2.15.2 with native extensions

Gem::Installer::ExtensionBuildError: ERROR: Failed to build gem native extension.

    /usr/bin/ruby2.0 extconf.rb
checking for gcc... yes
checking for Magick-config... no
checking for pkg-config... no
Can't install RMagick 2.15.2. Can't find Magick-config or pkg-config in /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
```

And similar errors for `uglifier` and another gem. Installing these additional packages solve all the issues.